### PR TITLE
feat: Allow users to setup their Chrome dev port, LLM  model and API settings in .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,17 @@
-# the model name must be gpt-4o-2024-08-06 as it is dependent on structured output from open ai
-MODEL_NAME="gpt-4o-2024-08-06"
+# The model name must be 'gpt-4o-2024-08-06' as it is dependent on structured output from OpenAI
 
 LITELLM_LOG="ERROR"
 
-OPENAI_API_KEY=""
+# OpenAI's API settings
+# Example TogetherAI endpoint
+OPENAI_BASE_URL=https://api.together.xyz/v1
+OPENAI_API_KEY=
+
+# The model to use for the LLM
+MODEL_NAME=meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
+
+# Port for Google crome dev mode
+CHROME_PORT=9222
 
 # you can skip adding langfuse api keys. refer to the readme on how to disable tracing with langfuse. 
 LANGFUSE_SECRET_KEY="sk-lf-"

--- a/agentq/core/web_driver/playwright.py
+++ b/agentq/core/web_driver/playwright.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 from typing import List, Union
@@ -190,7 +191,7 @@ class PlaywrightManager:
                 )
             else:
                 browser = await PlaywrightManager._playwright.chromium.connect_over_cdp(
-                    "http://localhost:9222"
+                    "http://localhost:{}".format(int(os.getenv("CHROME_PORT", "9222")))
                 )
                 PlaywrightManager._browser_context = browser.contexts[0]
 


### PR DESCRIPTION
I just made a minor feature addition to allow users to set their models and API in the `.env` file. This is more practical than having to change the code each time.